### PR TITLE
Update Makefile (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build:
 
 install:
 	mkdir -p $(DESTDIR)/usr/share/nwg-look
+	mkdir -p $(DESTDIR)/usr/bin
+	mkdir -p $(DESTDIR)/usr/share/applications
+	mkdir -p $(DESTDIR)/usr/share/pixmaps
 	cp stuff/main.glade $(DESTDIR)/usr/share/nwg-look/
 	cp stuff/nwg-look.desktop $(DESTDIR)/usr/share/applications/
 	cp stuff/nwg-look.svg $(DESTDIR)/usr/share/pixmaps/


### PR DESCRIPTION
When using DESTDIR it's likely $DESTDIR/ will be empty so the directory must be created before copying files