### PR TITLE
tools.go: respect color-scheme settings

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -537,6 +537,8 @@ func applyGsettingsFromFile() {
 						gsettings.eventSounds = value == "true"
 					case "input-feedback-sounds":
 						gsettings.inputFeedbackSounds = value == "true"
+                                        case "color-scheme":
+                                                gsettings.colorScheme = value
 					}
 				}
 			}


### PR DESCRIPTION
'nwg-look -a' always sets color-scheme=default.
With this commit the value stored in ~/.local/share/nwg-look/gsettings gets respected.