### PR TITLE
Fix #41

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Piotr Miller
+Copyright (c) 2022-2023 Piotr Miller & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "0.2.3"
+const version = "0.2.4"
 
 var (
 	preferences           programSettings

--- a/tools.go
+++ b/tools.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1078,7 +1076,7 @@ func iconThemeName(path string) (string, bool, error) {
 }
 
 func loadTextFile(path string) ([]string, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -1106,8 +1104,8 @@ func saveTextFile(text []string, path string) {
 	file.Close()
 }
 
-func listFiles(dir string) ([]fs.FileInfo, error) {
-	files, err := ioutil.ReadDir(dir)
+func listFiles(dir string) ([]os.DirEntry, error) {
+	files, err := os.ReadDir(dir)
 	if err == nil {
 		return files, nil
 	}

--- a/tools.go
+++ b/tools.go
@@ -1092,7 +1092,7 @@ func loadTextFile(path string) ([]string, error) {
 func saveTextFile(text []string, path string) {
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		log.Fatalf("Failed creating file: %s", err)
+		log.Warnf("Failed creating file: %s", err)
 	}
 	datawriter := bufio.NewWriter(file)
 


### PR DESCRIPTION
- fatal error on output path not found replaced with a warning, so from now it won't stop further program execution; closes #41;
- deprecated `ioutil` replaced with `os`.