### PR TITLE
Install prefix support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# For alternate install dir (e.g. "/usr/local")
+# specify PREFIX in make command:
+#   sudo make PREFIX=/usr/local install
+# Defaults to "/usr" if not specified.
+PREFIX ?= /usr
+
 get:
 	go get github.com/gotk3/gotk3
 	go get github.com/gotk3/gotk3/gdk
@@ -7,29 +13,29 @@ build:
 	go build -v -o bin/nwg-look .
 
 install:
-	mkdir -p $(DESTDIR)/usr/share/nwg-look
-	mkdir -p $(DESTDIR)/usr/share/nwg-look/langs
-	mkdir -p $(DESTDIR)/usr/bin
-	mkdir -p $(DESTDIR)/usr/share/applications
-	mkdir -p $(DESTDIR)/usr/share/pixmaps
+	mkdir -p $(DESTDIR)$(PREFIX)/share/nwg-look
+	mkdir -p $(DESTDIR)$(PREFIX)/share/nwg-look/langs
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
+	mkdir -p $(DESTDIR)$(PREFIX)/share/pixmaps
 
-	mkdir -p $(DESTDIR)/usr/share/doc/nwg-look
-	mkdir -p $(DESTDIR)/usr/share/licenses/nwg-look
+	mkdir -p $(DESTDIR)$(PREFIX)/share/doc/nwg-look
+	mkdir -p $(DESTDIR)$(PREFIX)/share/licenses/nwg-look
 
-	cp stuff/main.glade $(DESTDIR)/usr/share/nwg-look/
-	cp langs/* $(DESTDIR)/usr/share/nwg-look/langs/
-	cp stuff/nwg-look.desktop $(DESTDIR)/usr/share/applications/
-	cp stuff/nwg-look.svg $(DESTDIR)/usr/share/pixmaps/
-	cp bin/nwg-look $(DESTDIR)/usr/bin
+	cp stuff/main.glade $(DESTDIR)$(PREFIX)/share/nwg-look/
+	cp langs/* $(DESTDIR)$(PREFIX)/share/nwg-look/langs/
+	cp stuff/nwg-look.desktop $(DESTDIR)$(PREFIX)/share/applications/
+	cp stuff/nwg-look.svg $(DESTDIR)$(PREFIX)/share/pixmaps/
+	cp bin/nwg-look $(DESTDIR)$(PREFIX)/bin
 
-	cp README.md $(DESTDIR)/usr/share/doc/nwg-look
-	cp LICENSE $(DESTDIR)/usr/share/licenses/nwg-look
+	cp README.md $(DESTDIR)$(PREFIX)/share/doc/nwg-look
+	cp LICENSE $(DESTDIR)$(PREFIX)/share/licenses/nwg-look
 
 uninstall:
-	rm -r $(DESTDIR)/usr/share/nwg-look
-	rm $(DESTDIR)/usr/share/applications/nwg-look.desktop
-	rm $(DESTDIR)/usr/share/pixmaps/nwg-look.svg
-	rm $(DESTDIR)/usr/bin/nwg-look
+	rm -r $(DESTDIR)$(PREFIX)/share/nwg-look
+	rm $(DESTDIR)$(PREFIX)/share/applications/nwg-look.desktop
+	rm $(DESTDIR)$(PREFIX)/share/pixmaps/nwg-look.svg
+	rm $(DESTDIR)$(PREFIX)/bin/nwg-look
 
 run:
 	go run .

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 
@@ -352,7 +353,15 @@ func main() {
 		os.Exit(0)
 	}
 
-	builder, _ := gtk.BuilderNewFromFile("/usr/share/nwg-look/main.glade")
+	gladeFile := ""
+	for _, d := range dataDirs {
+		gladeFile = filepath.Join(d, "/nwg-look/main.glade")
+		if pathExists(gladeFile) {
+			break
+		}
+	}
+
+	builder, _ := gtk.BuilderNewFromFile(gladeFile)
 	win, _ := getWindow(builder, "window")
 
 	win.Connect("destroy", func() {


### PR DESCRIPTION
Use XDG_DATA_DIRS (or the hardcoded default if not set) as a "search path" for the `en_US.json` and `main.glade` data files. this allows installation to a prefix other than `/usr` (as long as XDG_DATA_DIRS is set accordingly). Includes primitive support in the Makefile for passing in an installation prefix. Addresses issue #52 