### PR TITLE
List gsettings as a dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ but nwg-look is intended to free the user from a few inconveniences:
 - go (build dependency)
 - gtk3
 - [xcur2png](https://github.com/eworm-de/xcur2png)
+- gsettings
 
 Depending on your distro, you may also need to install
 [gotk3 dependencies](https://github.com/gotk3/gotk3#installation).


### PR DESCRIPTION
nwg-look needs the gsettings binary to work, but it's not in the README. Because it wasn't there, I didn't add it as a dependency of the Debian package and so I got a [bug report](https://bugs.debian.org/10791730) about it. Thanks!