### PR TITLE
Fix the issue where the "listFiles" method does not resolve symbolic links

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "1.0.2"
+const version = "1.0.3"
 
 var (
 	preferences           programSettings

--- a/tools.go
+++ b/tools.go
@@ -1200,12 +1200,20 @@ func saveTextFile(text []string, path string) {
 	file.Close()
 }
 
-func listFiles(dir string) ([]os.DirEntry, error) {
+func listFiles(dir string) ([]os.FileInfo, error) {
 	files, err := os.ReadDir(dir)
-	if err == nil {
-		return files, nil
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+
+	var res []os.FileInfo
+	for _, f := range files {
+		if st, err := os.Stat(filepath.Join(dir, f.Name())); err == nil {
+			res = append(res, st)
+		}
+	}
+
+	return res, nil
 }
 
 func isIn(slice []string, val string) bool {


### PR DESCRIPTION
In Go 1.23, the `os.ReadDir` function uses `os.Lstat` to retrieve file information.

References:

[os/dir.go#L125](https://github.com/golang/go/blob/3902e9ef4e4543c6ac7371174a122ca090af971a/src/os/dir.go#L125) -> [os/dir.go#L101](https://github.com/golang/go/blob/3902e9ef4e4543c6ac7371174a122ca090af971a/src/os/dir.go#L101) -> [os/dir_unix.go#L151](https://github.com/golang/go/blob/3902e9ef4e4543c6ac7371174a122ca090af971a/src/os/dir_unix.go#L151)

This means that if a symlink exists in the themes directory, it cannot be resolved correctly (`IsDir` will return `false`). 
This PR addresses the issue by ensuring correct resolution.

For example, it fixes the resolution in NixOS, as discussed in [nwg-piotr/nwg-look#76](https://github.com/nwg-piotr/nwg-look/issues/76).