### PR TITLE
Fix typo in tools.go

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -130,7 +130,7 @@ func loadGtkConfig() {
 			}
 		}
 	} else {
-		log.Warnf("Could'n find %s", configFile)
+		log.Warnf("Could'nt find %s", configFile)
 	}
 	log.Debugf("gtk-theme-name: %s", gtkConfig.themeName)
 	log.Debugf("gtk-icon-theme-name: %s", gtkConfig.iconThemeName)


### PR DESCRIPTION
nwg-look can emit this error: WARN[0000] Could'n find /home/<user>/.config/gtk-3.0/settings.ini
This pull will fix the typo. 
