### PR TITLE
Fix `-x` and `-r` flags for GTK 4.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,6 +284,7 @@ func main() {
 	lang := detectLang()
 	log.Infof("lang: %s", lang)
 
+	dataDirs = getDataDirs()
 	voc = loadVocabulary(lang)
 
 	// initialize gsettings type with default gtk values
@@ -314,6 +315,7 @@ func main() {
 				saveXsettingsd()
 			}
 			if preferences.ExportGtk4Symlinks {
+				_, gtkThemePaths = getThemeNames()
 				linkGtk4Stuff()
 				saveGtkIni4()
 			} else {
@@ -351,7 +353,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	dataDirs = getDataDirs()
 	cursorThemes, cursorThemeNames = getCursorThemes()
 
 	gtk.Init(nil)

--- a/tools.go
+++ b/tools.go
@@ -1422,8 +1422,6 @@ func detectLang() string {
 }
 
 func loadVocabulary(lang string) map[string]string {
-	var dataDirs []string
-	dataDirs = getDataDirs()
 	for _, d := range dataDirs {
 		langsDir := filepath.Join(d, "/nwg-look/langs/")
 		enUSFile := filepath.Join(langsDir, "en_US.json")


### PR DESCRIPTION
Fix a simple "use before assignment" bug by ensuring `dataDirs` is set before calling `getThemeNames`.

Fixes #107

