### PR TITLE
Fix spelling mistake "could'nt"

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -130,7 +130,7 @@ func loadGtkConfig() {
 			}
 		}
 	} else {
-		log.Warnf("Could'nt find %s", configFile)
+		log.Warnf("Couldn't find %s", configFile)
 	}
 	log.Debugf("gtk-theme-name: %s", gtkConfig.themeName)
 	log.Debugf("gtk-icon-theme-name: %s", gtkConfig.iconThemeName)


### PR DESCRIPTION
The only spelling mistake I could find with [cspell](https://cspell.org/)